### PR TITLE
added run config for mkdocs so can debug in vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,16 @@
       "url": "http://localhost:8000/mkdocs-material/",
       "webRoot": "${workspaceFolder}",
       "smartStep": true
+    },
+    {
+      "name": "mkdocs serve",
+      "type":"python",
+      "program": "venv/bin/mkdocs",
+      "args": ["serve"],
+      "env": {
+        "PYTHONPATH": "."
+      },
+      "request": "launch"
     }
   ]
 }


### PR DESCRIPTION
I am having some troubles compiling the examples, so added a run configuration for debugging the `mkdocs` process. 

Should work for everyone and I can add a small tutorial or something? LMK where you would like that:

- main documentation under `customization/#environment-setup`?
- as a tutorial here in examples?
- on youtube somewhere? (got Screenflow, so recording something should be poss.)