### PR TITLE
added sanity check in case theme.features is not defined

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -49,7 +49,11 @@ def transform(project: MkDocsConfig, config: MkDocsConfig):
     project.copyright = config.copyright
 
     # Inherit settings for theme
-    project.theme["features"].extend(config.theme["features"])
+    if "features" in project.theme:
+        project.theme["features"].extend(config.theme["features"])
+    else:
+        project.theme["features"] = config.theme["features"]
+
     if "icon" in project.theme:
         merge(project.theme["icon"], config.theme["icon"])
     else:


### PR DESCRIPTION
I keep deleting the `theme.features` in `mkdocs.yml` and then the build breaks when building all the examples. It does not show when building an example on its own, which I guess is a bad idea, although faster. I assume there is no requirement to have `theme.features` defined, so I added a sanity check.