### PR TITLE
fixed warning about emoji logic

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,8 +72,8 @@ markdown_extensions:
       smart_enable: all
   - pymdownx.details
   - pymdownx.emoji:
-      emoji_generator: !!python/name:materialx.emoji.to_svg
-      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
   - pymdownx.highlight:
       anchor_linenums: true
   - pymdownx.keys


### PR DESCRIPTION
change should get rid of deprecation warning that "Material emoji logic has been officially moved into mkdocs-material".

This came up in the discussions as well, so I thought I'd fix it for our examples: https://github.com/squidfunk/mkdocs-material/discussions/6207 It is now as shown in the documentation as well, so fewer surprises.