### PR TITLE
added sanity check to make sure Material is configured

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -23,6 +23,7 @@ import posixpath
 
 from mergedeep import merge
 from mkdocs.config.defaults import MkDocsConfig
+from mkdocs.exceptions import  ConfigurationError
 
 # -----------------------------------------------------------------------------
 # Functions
@@ -48,13 +49,17 @@ def transform(project: MkDocsConfig, config: MkDocsConfig):
     # Inherit settings for copyright
     project.copyright = config.copyright
 
+    # check that a theme has been defined and we are not running with the default theme
+    if project.theme == "mkdocs":
+        raise ConfigurationError("Material is not defined as a theme, add it to mkdocs.yml")
+
     # Inherit settings for theme
-    if "features" in project.theme:
+    if project.theme and "features" in project.theme:
         project.theme["features"].extend(config.theme["features"])
     else:
         project.theme["features"] = config.theme["features"]
 
-    if "icon" in project.theme:
+    if project.theme and "icon" in project.theme:
         merge(project.theme["icon"], config.theme["icon"])
-    else:
+    else:        
         project.theme["icon"] = config.theme["icon"]

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -61,5 +61,5 @@ def transform(project: MkDocsConfig, config: MkDocsConfig):
 
     if project.theme and "icon" in project.theme:
         merge(project.theme["icon"], config.theme["icon"])
-    else:        
+    else:
         project.theme["icon"] = config.theme["icon"]

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -54,12 +54,12 @@ def transform(project: MkDocsConfig, config: MkDocsConfig):
         raise ConfigurationError("Material is not defined as a theme, add it to mkdocs.yml")
 
     # Inherit settings for theme
-    if project.theme and "features" in project.theme:
+    if "features" in project.theme:
         project.theme["features"].extend(config.theme["features"])
     else:
         project.theme["features"] = config.theme["features"]
 
-    if project.theme and "icon" in project.theme:
+    if "icon" in project.theme:
         merge(project.theme["icon"], config.theme["icon"])
     else:
         project.theme["icon"] = config.theme["icon"]


### PR DESCRIPTION
when creating a new project with `mkdocs new`, the default
mkdocs theme will be configured and `project.theme` will
be a string, not an object, so a sanity check now aborts
if it finds the default theme config.

Please squash before merging, made a couple of mistakes on the way