### PR TITLE
more fonts examples?

### DIFF
--- a/examples/fonts-builtin/docs/README.md
+++ b/examples/fonts-builtin/docs/README.md
@@ -16,7 +16,7 @@ is an option for you.
 Turn off the default use of Roboto fonts loaded from Google Fonts in
 your `mkdocs.ym`:
 
-```
+```yaml
 theme:
   font: false
 ```


### PR DESCRIPTION
Pushed up a small fix but am thinking about whether we need more font examples? We don't have the 2nd most basic one of simply changing to a different font that is also hosted on Google Fonts. Is that what you meant by "auto"? 

Btw. the section "autoloading" in the documentation seems to be a misnomer - it is about turning off the autoloading of fonts from Google? Perhaps I am not grasping the use of terminology.
