### PR TITLE
Fixed archive creation to include hidden paths

### DIFF
--- a/hooks/archive.py
+++ b/hooks/archive.py
@@ -71,7 +71,7 @@ def on_post_build(config: MkDocsConfig):
                     path = os.path.join(path, "**")
 
                 # Find all files recursively and add them to the archive
-                for file in iglob(path, recursive = True):
+                for file in iglob(path, recursive = True, include_hidden = True):
                     log.debug(f"+ '{file}'")
                     f.write(file, os.path.join(
                         example, os.path.relpath(file, base)


### PR DESCRIPTION
Hello, 
I downloaded the `blog-basic.zip` and running `mkdocs serve` leads to a `Couldn't find author` error.
It turned out that `.authors.yml` files aren't included in the blog archives, whereas the `.example.yml` files in the root of the example is included. I don't really understand it, but I added a fix that will make the blog examples functional again.