### PR TITLE
docs(tags, using tags with icons): Remove obsolet option tags_file

### DIFF
--- a/examples/tags-with-icons/mkdocs.yml
+++ b/examples/tags-with-icons/mkdocs.yml
@@ -39,8 +39,7 @@ theme:
 # Plugins
 plugins:
   - search
-  - tags:
-      tags_file: demo/tags.md
+  - tags
 
 # Extra configuration
 extra:

--- a/examples/tags/mkdocs.yml
+++ b/examples/tags/mkdocs.yml
@@ -34,9 +34,8 @@ theme:
 # Plugins
 plugins:
   - search
-  - tags:
-      tags_file: demo/tags.md
-
+  - tags
+  
 # Markdown extensions
 markdown_extensions:
   - attr_list


### PR DESCRIPTION
As per https://github.com/squidfunk/mkdocs-material/issues/7958

closes https://github.com/squidfunk/mkdocs-material/issues/7958